### PR TITLE
Added compositeName as a SwiftAddressBookPerson property

### DIFF
--- a/Pod/Classes/SwiftAddressBookWrapper.swift
+++ b/Pod/Classes/SwiftAddressBookWrapper.swift
@@ -384,6 +384,12 @@ public class SwiftAddressBookPerson : SwiftAddressBookRecord {
         }
     }
     
+    public var compositeName : String? {
+		get{
+			return ABRecordCopyCompositeName(self).takeRetainedValue()
+		}
+	}
+    
     public var firstName : String? {
         get {
             return extractProperty(kABPersonFirstNameProperty)


### PR DESCRIPTION
I did not create this method in the SwiftAddressBookRecord class because the docs say that it does not support ABAddressBookSources, which your Sources inherit from this Record class.

I also did not add this to the Group class because it has the same behavior as the .name property.