### PR TITLE
make records conform to hashable

### DIFF
--- a/Example/SwiftAddressBookTests/SwiftAddressBookPersonTests.swift
+++ b/Example/SwiftAddressBookTests/SwiftAddressBookPersonTests.swift
@@ -311,7 +311,26 @@ class SwiftAddressBookPersonTests: XCTestCase {
 		waitForExpectationsWithTimeout(waitTime, handler: nil)
 	}
 
-	
+	func testPeopleInHashBasedCollections() {
+
+		let testExpectation = expectationWithDescription("testPeopleInHashBasedCollections")
+
+		swiftAddressBook?.requestAccessWithCompletion({ (success, error) -> Void in
+			XCTAssertTrue(success, self.accessError)
+			if success {
+				if let allPeople = swiftAddressBook?.allPeople {
+					let allPeopleSet = Set(allPeople)
+					XCTAssertNotNil(allPeopleSet, "people should be storable in hash-based collections")
+				}
+			} else {
+				XCTAssertNotNil(error, self.accessErrorNil)
+			}
+
+			testExpectation.fulfill()
+		})
+
+		waitForExpectationsWithTimeout(waitTime, handler: nil)
+	}
 
 
 

--- a/Pod/Classes/SwiftAddressBookRecord.swift
+++ b/Pod/Classes/SwiftAddressBookRecord.swift
@@ -55,3 +55,15 @@ public class SwiftAddressBookRecord {
 		}
 	}
 }
+
+extension SwiftAddressBookRecord: Hashable {
+
+	public var hashValue: Int {
+		return recordID.hashValue
+	}
+
+}
+
+public func == (lhs: SwiftAddressBookRecord, rhs: SwiftAddressBookRecord) -> Bool {
+	return lhs.recordID == rhs.recordID
+}


### PR DESCRIPTION
This lets them be stored in hash-based collections such as dictionaries or sets.