### PR TITLE
Rare crash when address book has corrupted / uncopyable image

### DIFF
--- a/Pod/Classes/SwiftAddressBookPerson.swift
+++ b/Pod/Classes/SwiftAddressBookPerson.swift
@@ -62,7 +62,11 @@ public class SwiftAddressBookPerson : SwiftAddressBookRecord {
 	}
 
 	public var image : UIImage? {
-		return ABPersonHasImageData(internalRecord) ? UIImage(data: ABPersonCopyImageData(internalRecord).takeRetainedValue()) : nil
+		if let imageData = ABPersonCopyImageData(internalRecord)?.takeRetainedValue() {
+			return UIImage(data: imageData)
+		} else {
+			return nil
+		}
 	}
 
 	public func imageDataWithFormat(format : SwiftAddressBookPersonImageFormat) -> UIImage? {


### PR DESCRIPTION
I don't have steps to reproduce this bug, but sometimes ABPersonHasImageData returns true, but
ABPersonCopyImageData still returns nil. Seems like an iOS bug.
Here is only mention of this bug I've googled: https://issues.apache.org/jira/browse/CB-5698
(as a prove that it's not some error in my configuration/setup)